### PR TITLE
Dotnet 6.0.4 dependency

### DIFF
--- a/handbrake.install/handbrake.install.nuspec
+++ b/handbrake.install/handbrake.install.nuspec
@@ -54,7 +54,7 @@ I produce and maintain Chocolatey packages in my spare time, for free. If you us
 ]]></description>
     <releaseNotes>https://github.com/HandBrake/HandBrake/releases/tag/1.6.1</releaseNotes>
     <dependencies>
-      <dependency id="dotnet-6.0-desktopruntime" version="6.0.1" />
+      <dependency id="dotnet-6.0-desktopruntime" version="6.0.4" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
Handbrake won't open anymore with dotnet v6.0.1
Need to be updated to 6.0.4